### PR TITLE
Change builder version to 3.0 to support rails 3

### DIFF
--- a/google-ads-savon.gemspec
+++ b/google-ads-savon.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "akami",    "~> 1.2"
   s.add_dependency "gyoku",    "~> 1.2"
 
-  s.add_dependency "builder",  "~> 3.2"
+  s.add_dependency "builder",  "~> 3.0"
   s.add_dependency "nokogiri", "~> 1.6"
 
   s.add_development_dependency "rake",    "~> 10.1"


### PR DESCRIPTION
- after upgrade of reevoo/adwords-api gem to use latest AdwordsAPI version (v201705) we found out that new version with updated dependencies is incompatible with Rails 3. That means it is impossible to install this gem to revieworld. To be more correct, there is a conflict in version of Builder gem used by action_pack (3.22.4) and by google-ads-savon (1.0.2). The action_pack requires builder in version 3.0.0 and google-ads-savon requires bulder in version 3.2.0.
- we are going to link this gem to revieworld and by that replace the dependency on original google-ads-savon gem